### PR TITLE
Remove typo licence

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ If you like or are using this project, please give it a star. Thanks!
 ### Watch a short video clip (no audio)
 [![Watch the video](https://reversepocostorage.blob.core.windows.net/public-file-share/efcore-first-run.jpg)](https://reversepocostorage.blob.core.windows.net/public-file-share/efcore-first-run.mp4)
 
-## To remove trial limitations, you will require a licence key.
+## To remove trial limitations, you will require a License key.
 Free to academics (you need a .edu, .ac or .sch email address), not free for commercial use.
 
-Go to the [ReversePOCO](https://www.reversepoco.co.uk) website for your licence key.
+Go to the [ReversePOCO](https://www.reversepoco.co.uk) website for your License key.
 
 ### Upgrading v2 to v3
 Please read the [Upgrading documentation](https://github.com/sjh37/EntityFramework-Reverse-POCO-Code-First-Generator/wiki/Upgrading-from-v2-to-v3)


### PR DESCRIPTION
## Description:
This Pull Request fixes a typographical error in the README.md file.

## Changes Made:
Corrected "licence" to "License" in the README.md file.

## Additional Information:
This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

Thank you for considering this contribution.